### PR TITLE
feat：书架阅读器章节末尾向下滚动自动进入下一章

### DIFF
--- a/src/renderer/src/bookSource/components/FindBookReaderPanel.vue
+++ b/src/renderer/src/bookSource/components/FindBookReaderPanel.vue
@@ -413,7 +413,11 @@ const {
   readerPaneWrapRef,
 });
 
+const CHAPTER_ADVANCE_WHEEL_THRESHOLD = 260;
 let wheelAdvanceTimer: number | null = null;
+let wheelDeltaResetTimer: number | null = null;
+let accumulatedWheelDelta = 0;
+let accumulatedWheelDirection: 1 | -1 | 0 = 0;
 
 /**
  * 书架在线阅读：正文已经到达本章底部后，用户再次向下滚动时进入下一章。
@@ -434,7 +438,24 @@ function onLayoutWheel(ev: WheelEvent) {
 
   // 一个连续滚轮手势可能产生多个 wheel 事件，只允许合并后的动作触发一次。
   if (wheelAdvanceTimer !== null) return;
-  const goingDown = ev.deltaY > 0;
+  const direction: 1 | -1 = ev.deltaY > 0 ? 1 : -1;
+  if (accumulatedWheelDirection !== direction) {
+    accumulatedWheelDirection = direction;
+    accumulatedWheelDelta = 0;
+  }
+  accumulatedWheelDelta += Math.abs(ev.deltaY);
+
+  if (wheelDeltaResetTimer !== null) window.clearTimeout(wheelDeltaResetTimer);
+  wheelDeltaResetTimer = window.setTimeout(() => {
+    wheelDeltaResetTimer = null;
+    accumulatedWheelDelta = 0;
+    accumulatedWheelDirection = 0;
+  }, 180);
+
+  // 小幅滚动只用于阅读，不触发章节切换；需要明显的大幅度连续滚动。
+  if (accumulatedWheelDelta < CHAPTER_ADVANCE_WHEEL_THRESHOLD) return;
+
+  const goingDown = direction === 1;
   const atBoundary = goingDown
     ? viewportAtBottom.value && canGoNextChapter.value
     : viewportTopLine.value <= 1 && canGoPrevChapter.value;
@@ -442,6 +463,12 @@ function onLayoutWheel(ev: WheelEvent) {
 
   wheelAdvanceTimer = window.setTimeout(() => {
     wheelAdvanceTimer = null;
+    if (wheelDeltaResetTimer !== null) {
+      window.clearTimeout(wheelDeltaResetTimer);
+      wheelDeltaResetTimer = null;
+    }
+    accumulatedWheelDelta = 0;
+    accumulatedWheelDirection = 0;
     const targetIndex = displayIndexForReadingOrder(
       currentReadingOrderIndex.value + (goingDown ? 1 : -1),
       displayChapters.value.length,
@@ -457,6 +484,9 @@ function onLayoutWheel(ev: WheelEvent) {
 
 onBeforeUnmount(() => {
   if (wheelAdvanceTimer !== null) window.clearTimeout(wheelAdvanceTimer);
+  if (wheelDeltaResetTimer !== null) window.clearTimeout(wheelDeltaResetTimer);
+  accumulatedWheelDelta = 0;
+  accumulatedWheelDirection = 0;
 });
 
 const sidebarShellVisible = computed(() =>

--- a/src/renderer/src/bookSource/components/FindBookReaderPanel.vue
+++ b/src/renderer/src/bookSource/components/FindBookReaderPanel.vue
@@ -231,6 +231,7 @@ const {
   fastScrollSensitivity,
   stickyChapterTitleEnabled,
   chapterNavToolbarEnabled,
+  findBookChapterAdvanceMode,
   selectionToolbarButtons,
   dictionarySettings,
   webSearchSettings,
@@ -420,9 +421,9 @@ let wheelAdvanceTimer: number | null = null;
  */
 function onLayoutWheel(ev: WheelEvent) {
   onFullscreenLayoutWheel(ev);
-  if (ev.deltaY <= 0 || !readerPaneWrapRef.value) return;
+  if (!readerPaneWrapRef.value || ev.deltaY === 0) return;
   if (!(ev.target instanceof Node) || !readerPaneWrapRef.value.contains(ev.target)) return;
-  if (!viewportAtBottom.value || !canGoNextChapter.value) return;
+  if (findBookChapterAdvanceMode.value === "default") return;
   if (
     chapterContentBusy.value ||
     readerEditMode.value ||
@@ -433,9 +434,24 @@ function onLayoutWheel(ev: WheelEvent) {
 
   // 一个连续滚轮手势可能产生多个 wheel 事件，只允许合并后的动作触发一次。
   if (wheelAdvanceTimer !== null) return;
+  const goingDown = ev.deltaY > 0;
+  const atBoundary = goingDown
+    ? viewportAtBottom.value && canGoNextChapter.value
+    : viewportTopLine.value <= 1 && canGoPrevChapter.value;
+  if (!atBoundary) return;
+
   wheelAdvanceTimer = window.setTimeout(() => {
     wheelAdvanceTimer = null;
-    advanceToNextChapterForAutoRead();
+    const targetIndex = displayIndexForReadingOrder(
+      currentReadingOrderIndex.value + (goingDown ? 1 : -1),
+      displayChapters.value.length,
+      chapterSortDesc.value,
+    );
+    void loadChapterAtDisplayIndex(targetIndex, {
+      appendToCurrent:
+        findBookChapterAdvanceMode.value === "seamless" && goingDown,
+      smoothScroll: findBookChapterAdvanceMode.value !== "seamless",
+    });
   }, 80);
 }
 

--- a/src/renderer/src/bookSource/components/FindBookReaderPanel.vue
+++ b/src/renderer/src/bookSource/components/FindBookReaderPanel.vue
@@ -403,13 +403,44 @@ const readerPaneWrapRef = useTemplateRef<HTMLElement>("readerPaneWrapRef");
 const {
   fullscreenReaderPaneStyle,
   onLayoutMouseDown: onFullscreenLayoutMouseDown,
-  onLayoutWheel,
+  onLayoutWheel: onFullscreenLayoutWheel,
 } = useAppFullscreenReaderLayout({
   isFullscreenView,
   readerRef,
   fullscreenSidebarOverlayRef,
   fullscreenReaderWidthPercent,
   readerPaneWrapRef,
+});
+
+let wheelAdvanceTimer: number | null = null;
+
+/**
+ * 书架在线阅读：正文已经到达本章底部后，用户再次向下滚动时进入下一章。
+ * 只处理正文区域，避免滚动章节侧栏时意外跳章；定时滚动和语音朗读仍走各自逻辑。
+ */
+function onLayoutWheel(ev: WheelEvent) {
+  onFullscreenLayoutWheel(ev);
+  if (ev.deltaY <= 0 || !readerPaneWrapRef.value) return;
+  if (!(ev.target instanceof Node) || !readerPaneWrapRef.value.contains(ev.target)) return;
+  if (!viewportAtBottom.value || !canGoNextChapter.value) return;
+  if (
+    chapterContentBusy.value ||
+    readerEditMode.value ||
+    voiceRead.isVoiceReadNavigationBlocked.value
+  ) {
+    return;
+  }
+
+  // 一个连续滚轮手势可能产生多个 wheel 事件，只允许合并后的动作触发一次。
+  if (wheelAdvanceTimer !== null) return;
+  wheelAdvanceTimer = window.setTimeout(() => {
+    wheelAdvanceTimer = null;
+    advanceToNextChapterForAutoRead();
+  }, 80);
+}
+
+onBeforeUnmount(() => {
+  if (wheelAdvanceTimer !== null) window.clearTimeout(wheelAdvanceTimer);
 });
 
 const sidebarShellVisible = computed(() =>

--- a/src/renderer/src/bookSource/components/FindBookSettingsPanel.vue
+++ b/src/renderer/src/bookSource/components/FindBookSettingsPanel.vue
@@ -168,6 +168,7 @@ const draftMouseWheelScrollSensitivity = ref(
 const draftFastScrollSensitivity = ref(defaultFastScrollSensitivity);
 const draftStickyChapterTitleEnabled = ref(defaultStickyChapterTitleEnabled);
 const draftChapterNavToolbarEnabled = ref(defaultChapterNavToolbarEnabled);
+const draftFindBookChapterAdvanceMode = ref(fbReaderSettings.findBookChapterAdvanceMode.value);
 const draftReaderEditShowLineNumbers = ref(defaultReaderEditShowLineNumbers);
 const draftReaderEditMinimap = ref(defaultReaderEditMinimap);
 const draftChapterTitleBlankMode = ref(
@@ -278,6 +279,7 @@ function syncSharedReaderDraftFromStore() {
   );
   draftStickyChapterTitleEnabled.value = fb.stickyChapterTitleEnabled.value;
   draftChapterNavToolbarEnabled.value = fb.chapterNavToolbarEnabled.value;
+  draftFindBookChapterAdvanceMode.value = fb.findBookChapterAdvanceMode.value;
   draftReaderEditShowLineNumbers.value = fb.readerEditShowLineNumbers.value;
   draftReaderEditMinimap.value = fb.readerEditMinimap.value;
   draftChapterTitleBlankMode.value =
@@ -535,6 +537,7 @@ async function onConfirm() {
   );
   fb.stickyChapterTitleEnabled.value = draftStickyChapterTitleEnabled.value;
   fb.chapterNavToolbarEnabled.value = draftChapterNavToolbarEnabled.value;
+  fb.findBookChapterAdvanceMode.value = draftFindBookChapterAdvanceMode.value;
   fb.readerEditShowLineNumbers.value = draftReaderEditShowLineNumbers.value;
   fb.readerEditMinimap.value = draftReaderEditMinimap.value;
   fb.chapterTitleBlankMode.value =
@@ -680,6 +683,7 @@ watch(draftFontSize, (size) => {
               v-model:draft-fast-scroll-sensitivity="draftFastScrollSensitivity"
               v-model:draft-sticky-chapter-title-enabled="draftStickyChapterTitleEnabled"
               v-model:draft-chapter-nav-toolbar-enabled="draftChapterNavToolbarEnabled"
+              v-model:draft-find-book-chapter-advance-mode="draftFindBookChapterAdvanceMode"
               v-model:draft-chapter-title-blank-mode="draftChapterTitleBlankMode"
               v-model:draft-compress-blank-keep-one-blank="draftCompressBlankKeepOneBlank"
               v-model:draft-txtr-delimited-match-cross-line="draftTxtrDelimitedMatchCrossLine"

--- a/src/renderer/src/bookSource/composables/useFindBookChapterSession.ts
+++ b/src/renderer/src/bookSource/composables/useFindBookChapterSession.ts
@@ -519,7 +519,11 @@ export function useFindBookChapterSession(deps: FindBookChapterSessionDeps) {
 
   async function loadChapterAtDisplayIndex(
     index: number,
-    options?: { smoothScroll?: boolean; preferCache?: boolean },
+    options?: {
+      smoothScroll?: boolean;
+      preferCache?: boolean;
+      appendToCurrent?: boolean;
+    },
   ) {
     const ch = deps.displayChapters.value[index];
     if (!ch) return;
@@ -559,7 +563,7 @@ export function useFindBookChapterSession(deps: FindBookChapterSessionDeps) {
     cancelChapterLoad();
     // 先启动侧栏居中动画，避免与 Monaco 正文写入抢主线程导致卡顿
     const scrollDone = deps.scrollChapterListToCurrent({ smooth: wantSmooth });
-    if (!fromCache) {
+    if (!fromCache && !options?.appendToCurrent) {
       // 未缓存 / 强制刷新：遮罩盖住旧正文，切章期间不做 Monaco 清空（避免卡列表动画）
       readerContentKey.value = null;
       lastChapterTitle.value = "";
@@ -616,9 +620,17 @@ export function useFindBookChapterSession(deps: FindBookChapterSessionDeps) {
       deps.markChapterCached(ch.url);
       readerContentKey.value = `findbook://${d.bookUrl}#${ch.url}`;
       // IPC 返回缓存/联网原文；文本替换在 renderChapterText 中与「转换」一并套用
-      lastChapterTitle.value = displayTitle || ch.title;
-      lastChapterBody.value = body;
-      await renderChapterText(lastChapterTitle.value, body);
+      const nextTitle = displayTitle || ch.title;
+      if (options?.appendToCurrent && lastChapterBody.value) {
+        // 保留当前滚动位置，把下一章正文追加到现有内容末尾，实现连续阅读。
+        lastChapterBody.value = `${lastChapterBody.value}\n\n${nextTitle}\n${body}`;
+        lastChapterTitle.value = "";
+        await renderChapterText("", lastChapterBody.value, { resetScroll: false });
+      } else {
+        lastChapterTitle.value = nextTitle;
+        lastChapterBody.value = body;
+        await renderChapterText(lastChapterTitle.value, body);
+      }
       if (deps.isInBookshelf(d.bookUrl, it.origin)) {
         deps.updateReadProgress(d.bookUrl, it.origin, contentIndex, ch.title);
       }

--- a/src/renderer/src/bookSource/composables/useFindBookChapterSession.ts
+++ b/src/renderer/src/bookSource/composables/useFindBookChapterSession.ts
@@ -637,7 +637,10 @@ export function useFindBookChapterSession(deps: FindBookChapterSessionDeps) {
     } finally {
       loading.value = false;
       showChapterLoadingUi.value = false;
-      await ensureChapterScrollAtTop();
+      // 无缝追加已经保留了当前视口；只有普通章节跳转才回到新章节顶部。
+      if (!options?.appendToCurrent) {
+        await ensureChapterScrollAtTop();
+      }
     }
   }
 

--- a/src/renderer/src/bookSource/composables/useFindBookReaderSettings.ts
+++ b/src/renderer/src/bookSource/composables/useFindBookReaderSettings.ts
@@ -383,6 +383,7 @@ function createFindBookReaderSettingsStore() {
     fastScrollSensitivity: fb.fastScrollSensitivity,
     stickyChapterTitleEnabled: fb.stickyChapterTitleEnabled,
     chapterNavToolbarEnabled: fb.chapterNavToolbarEnabled,
+    findBookChapterAdvanceMode: fb.findBookChapterAdvanceMode,
     selectionToolbarButtons: fb.selectionToolbarButtons,
     dictionarySettings: fb.dictionarySettings,
     webSearchSettings: fb.webSearchSettings,

--- a/src/renderer/src/bookSource/composables/useFindBookSettings.ts
+++ b/src/renderer/src/bookSource/composables/useFindBookSettings.ts
@@ -59,6 +59,7 @@ function createFindBookSettingsStore() {
   const fastScrollSensitivity = ref(initial.fastScrollSensitivity);
   const stickyChapterTitleEnabled = ref(initial.stickyChapterTitleEnabled);
   const chapterNavToolbarEnabled = ref(initial.chapterNavToolbarEnabled);
+  const findBookChapterAdvanceMode = ref(initial.findBookChapterAdvanceMode);
   const readerEditShowLineNumbers = ref(initial.readerEditShowLineNumbers);
   const readerEditMinimap = ref(initial.readerEditMinimap);
   const fullscreenReaderWidthPercent = ref(initial.fullscreenReaderWidthPercent);
@@ -119,6 +120,7 @@ function createFindBookSettingsStore() {
       fastScrollSensitivity: fastScrollSensitivity.value,
       stickyChapterTitleEnabled: stickyChapterTitleEnabled.value,
       chapterNavToolbarEnabled: chapterNavToolbarEnabled.value,
+      findBookChapterAdvanceMode: findBookChapterAdvanceMode.value,
       readerEditShowLineNumbers: readerEditShowLineNumbers.value,
       readerEditMinimap: readerEditMinimap.value,
       fullscreenReaderWidthPercent: fullscreenReaderWidthPercent.value,
@@ -283,6 +285,7 @@ function createFindBookSettingsStore() {
     fastScrollSensitivity,
     stickyChapterTitleEnabled,
     chapterNavToolbarEnabled,
+    findBookChapterAdvanceMode,
     readerEditShowLineNumbers,
     readerEditMinimap,
     fullscreenReaderWidthPercent,

--- a/src/renderer/src/bookSource/services/findBookSettingsStore.ts
+++ b/src/renderer/src/bookSource/services/findBookSettingsStore.ts
@@ -59,6 +59,11 @@ import type { DictionarySettings } from "@shared/dictionaryTypes";
 import type { WebSearchSettings } from "@shared/webSearchTypes";
 import { READER_EDITOR_DEFAULT_FONT_FAMILY } from "../../monaco/readerEditorOptions";
 import {
+  DEFAULT_FIND_BOOK_CHAPTER_ADVANCE_MODE,
+  isFindBookChapterAdvanceMode,
+  type FindBookChapterAdvanceMode,
+} from "../../constants/findBookChapterAdvance";
+import {
   resolveDefaultBookSourceDownloadDirSync,
   resolveDefaultBookSourceChapterCacheDirSync,
 } from "../../utils/defaultCacheDirs";
@@ -203,6 +208,7 @@ export type SharedReaderSettingsSnapshot = {
   fastScrollSensitivity: number;
   stickyChapterTitleEnabled: boolean;
   chapterNavToolbarEnabled: boolean;
+  findBookChapterAdvanceMode: FindBookChapterAdvanceMode;
   readerEditShowLineNumbers: boolean;
   readerEditMinimap: boolean;
   fullscreenReaderWidthPercent: number;
@@ -304,6 +310,11 @@ export function sharedReaderSettingsFromMainData(
       typeof data.chapterNavToolbarEnabled === "boolean"
         ? data.chapterNavToolbarEnabled
         : defaultChapterNavToolbarEnabled,
+    findBookChapterAdvanceMode: isFindBookChapterAdvanceMode(
+      data.findBookChapterAdvanceMode,
+    )
+      ? data.findBookChapterAdvanceMode
+      : DEFAULT_FIND_BOOK_CHAPTER_ADVANCE_MODE,
     readerEditShowLineNumbers:
       typeof data.readerEditShowLineNumbers === "boolean"
         ? data.readerEditShowLineNumbers
@@ -360,6 +371,7 @@ export function snapshotSharedReaderSettingsForMain(
     fastScrollSensitivity: state.fastScrollSensitivity,
     stickyChapterTitleEnabled: state.stickyChapterTitleEnabled,
     chapterNavToolbarEnabled: state.chapterNavToolbarEnabled,
+    findBookChapterAdvanceMode: state.findBookChapterAdvanceMode,
     readerEditShowLineNumbers: state.readerEditShowLineNumbers,
     readerEditMinimap: state.readerEditMinimap,
     fullscreenReaderWidthPercent: state.fullscreenReaderWidthPercent,

--- a/src/renderer/src/components/SettingsReadingPanel.vue
+++ b/src/renderer/src/components/SettingsReadingPanel.vue
@@ -48,6 +48,10 @@ import {
 import SettingsSelectionToolbarPreview from "./SettingsSelectionToolbarPreview.vue";
 import { computed } from "vue";
 import { icons } from "../icons.js";
+import {
+  FIND_BOOK_CHAPTER_ADVANCE_MODE_OPTIONS,
+  type FindBookChapterAdvanceMode,
+} from "../constants/findBookChapterAdvance";
 
 const props = withDefaults(
   defineProps<{
@@ -62,6 +66,7 @@ const props = withDefaults(
     draftFastScrollSensitivity: number;
     draftStickyChapterTitleEnabled: boolean;
     draftChapterNavToolbarEnabled: boolean;
+    draftFindBookChapterAdvanceMode?: FindBookChapterAdvanceMode;
     draftChapterTitleBlankMode: ChapterTitleBlankMode;
     draftCompressBlankKeepOneBlank: boolean;
     draftTxtrDelimitedMatchCrossLine: boolean;
@@ -89,6 +94,7 @@ const props = withDefaults(
     showFindTargetOption: true,
     showAnnotationTools: true,
     showAskAi: true,
+    draftFindBookChapterAdvanceMode: "default",
   },
 );
 
@@ -104,6 +110,7 @@ defineEmits<{
   "update:draftFastScrollSensitivity": [v: number];
   "update:draftStickyChapterTitleEnabled": [v: boolean];
   "update:draftChapterNavToolbarEnabled": [v: boolean];
+  "update:draftFindBookChapterAdvanceMode": [v: FindBookChapterAdvanceMode];
   "update:draftChapterTitleBlankMode": [v: ChapterTitleBlankMode];
   "update:draftCompressBlankKeepOneBlank": [v: boolean];
   "update:draftTxtrDelimitedMatchCrossLine": [v: boolean];
@@ -133,6 +140,13 @@ const chapterTitleBlankSelectItems = computed<CustomSelectItem[]>(() =>
   })),
 );
 const selectListsEmpty: CustomSelectItem[] = [];
+const chapterAdvanceModeSelectItems = computed<CustomSelectItem[]>(() =>
+  FIND_BOOK_CHAPTER_ADVANCE_MODE_OPTIONS.map((o) => ({
+    kind: "item" as const,
+    id: o.id,
+    label: o.label,
+  })),
+);
 </script>
 
 <template>
@@ -287,6 +301,28 @@ const selectListsEmpty: CustomSelectItem[] = [];
         </div>
         <p class="settingsHint">
           在阅读区底部显示「上一章 / 下一章」快捷跳转；仅一章或无章节时不显示。
+        </p>
+      </div>
+
+      <div class="settingsRow">
+        <div class="settingsRowMain">
+          <span class="settingsLabel">章节末尾向下滚动行为</span>
+          <AppCustomSelect
+            class="settingsSelect"
+            :model-value="draftFindBookChapterAdvanceMode"
+            :display-label="FIND_BOOK_CHAPTER_ADVANCE_MODE_OPTIONS.find((o) => o.id === draftFindBookChapterAdvanceMode)?.label ?? '默认设置'"
+            :fixed-top-items="selectListsEmpty"
+            :scroll-items="chapterAdvanceModeSelectItems"
+            :fixed-bottom-items="selectListsEmpty"
+            aria-label="章节末尾向下滚动行为"
+            ariaLabel="章节末尾向下滚动行为"
+            @update:model-value="
+              $emit('update:draftFindBookChapterAdvanceMode', $event as FindBookChapterAdvanceMode)
+            "
+          />
+        </div>
+        <p class="settingsHint">
+          找书 beta 阅读到章节末尾后再次向下滚动时：默认设置不自动续章；无缝衔接会把下一章接在当前内容后；当前的跳转逻辑会切换到下一章顶部。
         </p>
       </div>
     </div>

--- a/src/renderer/src/constants/findBookChapterAdvance.ts
+++ b/src/renderer/src/constants/findBookChapterAdvance.ts
@@ -1,0 +1,16 @@
+export type FindBookChapterAdvanceMode = "default" | "seamless" | "jump";
+
+export const DEFAULT_FIND_BOOK_CHAPTER_ADVANCE_MODE: FindBookChapterAdvanceMode =
+  "default";
+
+export const FIND_BOOK_CHAPTER_ADVANCE_MODE_OPTIONS = [
+  { id: "default" as const, label: "默认设置" },
+  { id: "seamless" as const, label: "无缝衔接" },
+  { id: "jump" as const, label: "当前的跳转逻辑" },
+];
+
+export function isFindBookChapterAdvanceMode(
+  value: unknown,
+): value is FindBookChapterAdvanceMode {
+  return value === "default" || value === "seamless" || value === "jump";
+}

--- a/src/renderer/src/constants/findBookChapterAdvance.ts
+++ b/src/renderer/src/constants/findBookChapterAdvance.ts
@@ -6,7 +6,7 @@ export const DEFAULT_FIND_BOOK_CHAPTER_ADVANCE_MODE: FindBookChapterAdvanceMode 
 export const FIND_BOOK_CHAPTER_ADVANCE_MODE_OPTIONS = [
   { id: "default" as const, label: "默认设置" },
   { id: "seamless" as const, label: "无缝衔接" },
-  { id: "jump" as const, label: "当前的跳转逻辑" },
+  { id: "jump" as const, label: "跳转" },
 ];
 
 export function isFindBookChapterAdvanceMode(

--- a/src/renderer/src/stores/cacheStore.ts
+++ b/src/renderer/src/stores/cacheStore.ts
@@ -48,6 +48,7 @@ import {
   mergeAiSkillsEnabled,
 } from "@shared/aiSkills";
 import type { VoiceReadSettings } from "../constants/voiceRead";
+import type { FindBookChapterAdvanceMode } from "../constants/findBookChapterAdvance";
 import {
   mergeTimedScrollSettings,
   type TimedScrollSettings,
@@ -130,6 +131,8 @@ export type PersistedSettingsData = {
   stickyChapterTitleEnabled?: boolean;
   /** 阅读区底部「上一章 / 下一章」工具栏 */
   chapterNavToolbarEnabled?: boolean;
+  /** 找书阅读器章节末尾向下滚动的续章方式 */
+  findBookChapterAdvanceMode?: FindBookChapterAdvanceMode;
   /** 编辑模式下是否显示行号 */
   readerEditShowLineNumbers?: boolean;
   /** 编辑模式下是否显示小地图 */


### PR DESCRIPTION
## 改动说明

在“找书 beta”的书架阅读器中增加章节连续阅读体验，并提供可配置的章节边界行为：

- 当前章节滚动到末尾后，向下大幅度滚轮自动进入下一章
- 当前章节滚动到顶部后，向上大幅度滚轮可以进入上一章
- 采用连续滚动累计阈值，轻微滚动不会误触发跳章；方向改变或停顿后重新累计
- 在线加载章节和本地缓存章节均支持
- 仅响应正文区域的滚动，滚动章节侧栏不会误触发
- 增加重复滚轮事件保护，避免一次操作连续跳过多个章节
- 加载中、编辑模式和语音朗读导航锁定时不会自动跳章
- 设置中新增三种模式：默认设置、无缝衔接、跳转
- 无缝衔接模式会把下一章内容接在当前内容后，并保留当前阅读位置

## 设置入口

打开“找书 beta”后，依次进入：

`设置 → 阅读 → 章节末尾向下滚动行为`

## 修改文件

- `src/renderer/src/bookSource/components/FindBookReaderPanel.vue`
- `src/renderer/src/bookSource/composables/useFindBookChapterSession.ts`
- 阅读设置与持久化相关文件

## 验证情况

- 生产构建成功
- macOS arm64 安装包构建成功
