### PR TITLE
fix(reader): 空格翻页时保留上一页最后一条完整行

### DIFF
--- a/docs/基础功能.md
+++ b/docs/基础功能.md
@@ -274,7 +274,7 @@ Monaco `stickyScroll` + `chapterStickyScroll.ts` 的 DocumentSymbolProvider 在�
     - `App.vue` 在 **`.layout`** 上监听 **`@wheel`**，由 `useAppFullscreenReaderLayout.onLayoutWheel` 判断指针是否在 `readerPaneWrap` 矩形**之外**（左右空白）；且事件与全屏侧栏无关时，调用 `ReaderMain` 的 **`delegateEditorWheelFromBrowserEvent(ev)`**。
     - 内部对编辑器实例调用 **`delegateScrollFromMouseWheelEvent`**（`CodeEditorWidget` 运行时方法，未写入 `monaco` 的 `.d.ts`），与正文内滚轮走**同一条** Monaco 滚动逻辑。
 - **`preventDefault` 顺序**：Monaco 在 `_onMouseWheel` 开头若发现 **`ev.defaultPrevented` 已为 true 会直接 return**，故 **`delegateEditorWheelFromBrowserEvent` 须在 `preventDefault` 之前调用**；委托完成后再对布局层 `preventDefault()`。侧栏内滚动通过 `composedPath` / `elementFromPoint` 与 Shadow DOM 向上判定排除，避免误劫持。
-- **其它滚动**：键盘方向键、PageUp/PageDown 等仍由 `ReaderMain` 的 **`scrollByDeltaY` / `scrollByLineStep` / `scrollByPageStep`** 等驱动，与上述空白区 wheel 委托无关。
+- **其它滚动**：键盘方向键、PageUp/PageDown 等仍由 `ReaderMain` 的 **`scrollByDeltaY` / `scrollByLineStep` / `scrollByPageStep`** 等驱动，与上述空白区 wheel 委托无关。向下翻屏读取 Monaco 的最后一条完整可见视觉行，并将它对齐到新页粘性章节条下方，使新页第一行正好是上一页最下面的完整一行。
 - **样式**：全屏时 Monaco 纵向滚动条、概览尺、**小地图**（编辑态开启时）通过 `appShell.css` 固定到视口最右侧：滚动条/概览尺 `right: 0`，小地图 `right: var(--txtr-fullscreen-scrollbar-size)`（默认 14px，与 Monaco 默认竖条宽度一致）；须 **`left: auto`** 覆盖 Monaco 内联 `left`，避免小地图落在居中正文中间。与窄正文居中并存。
 
 ## 阅读器字号、行间距、字间距与段间距

--- a/src/renderer/src/components/ReaderMain.vue
+++ b/src/renderer/src/components/ReaderMain.vue
@@ -13,6 +13,8 @@ import kingHwaFontUrl from "../assets/KingHwa_OldSong1.0.ttf?url";
 import {
   type ChapterStickyLine,
   ensureStickyChapterBarClickDisabled,
+  getStickyChapterScrollHeight,
+  predictStickyChapterScrollHeight,
   refreshStickyChapterScrollWidget,
   registerChapterStickyScrollProviders,
 } from "../monaco/chapterStickyScroll";
@@ -2923,8 +2925,38 @@ function scrollByPageStep(direction: -1 | 1) {
     e.getOption(monaco.editor.EditorOption.lineHeight),
   );
   const viewportHeight = Math.max(1, e.getLayoutInfo().height);
-  // 预留两行，避免翻屏后阅读点跳得过猛。
-  const step = Math.max(lineHeight, viewportHeight - lineHeight * 2);
+
+  if (direction > 0) {
+    // getVisibleRanges 仅返回完整可见的视觉行；取最后一行并对齐到新页
+    // 粘性章节条下方。软换行边界列会映射到下一视觉行，故向前退一列。
+    const visibleRanges = e.getVisibleRanges();
+    const lastVisibleRange = visibleRanges[visibleRanges.length - 1];
+    if (lastVisibleRange) {
+      const lastCompleteLineTop = e.getScrolledVisiblePosition({
+        lineNumber: lastVisibleRange.endLineNumber,
+        column: Math.max(1, lastVisibleRange.endColumn - 1),
+      })?.top;
+      if (lastCompleteLineTop != null) {
+        // 落点处 sticky 可能增减行数，须按落点预测，不能复用当前 DOM 高度。
+        const stickyHeight = predictStickyChapterScrollHeight(
+          e,
+          chaptersSnapshot,
+          lastVisibleRange.endLineNumber,
+        );
+        // 视口过短、无法前进至少一行时，交给固定步长回退路径。
+        if (lastCompleteLineTop - stickyHeight >= lineHeight) {
+          scrollByDeltaY(lastCompleteLineTop - stickyHeight);
+          return;
+        }
+      }
+    }
+  }
+
+  // 回退步长：相邻两页共享一条视觉行。
+  const step = Math.max(
+    lineHeight,
+    viewportHeight - getStickyChapterScrollHeight(e) - lineHeight,
+  );
   scrollByDeltaY(direction * step);
 }
 

--- a/src/renderer/src/monaco/chapterStickyScroll.ts
+++ b/src/renderer/src/monaco/chapterStickyScroll.ts
@@ -1,5 +1,5 @@
 import type * as monaco from "monaco-editor";
-import { Emitter } from "monaco-editor";
+import { Emitter, editor as monacoEditor } from "monaco-editor";
 import { chapterTitleForDisplay } from "../chapter";
 
 /** 与 `setChapters` / 粘性滚动大纲一致的单条章节信息 */
@@ -52,6 +52,16 @@ export function ensureStickyChapterBarClickDisabled(): void {
 `;
 }
 
+/** 当前覆盖正文的 Monaco 粘性章节条高度。 */
+export function getStickyChapterScrollHeight(
+  editor: monaco.editor.ICodeEditor,
+): number {
+  const widget = editor
+    .getDomNode()
+    ?.querySelector<HTMLElement>(".sticky-widget");
+  return widget?.clientHeight ?? 0;
+}
+
 export type ChapterStickyScrollProvidersHandle = {
   disposable: monaco.IDisposable;
   /**
@@ -100,6 +110,61 @@ function rangeEndLineForTocIndex(
     }
   }
   return maxLine;
+}
+
+/**
+ * `lineNumber` 成为章节条下方第一行时，预测会保持粘性的章节层数。
+ * 范围边界与上方 DocumentSymbol 保持一致，并对齐 Monaco 的 candidate 规则。
+ */
+function countStickyChapterRowsForLine(
+  chapters: readonly ChapterStickyLine[],
+  lineNumber: number,
+  maxLine: number,
+): number {
+  const sorted = sortChaptersByTocOrder(
+    chapters.filter((c) => c.lineNumber >= 1 && c.lineNumber <= maxLine),
+  );
+  let rows = 0;
+  const countedStartLines = new Set<number>();
+  for (let i = 0; i < sorted.length; i++) {
+    const start = sorted[i]!.lineNumber;
+    if (start >= lineNumber || countedStartLines.has(start)) continue;
+    const end = rangeEndLineForTocIndex(sorted, i, maxLine);
+    // Monaco 只为至少跨三行的 DocumentSymbol 创建 sticky candidate。
+    if (end > start + 1 && lineNumber <= end) {
+      countedStartLines.add(start);
+      rows++;
+    }
+  }
+  return rows;
+}
+
+/** 预测指定行成为正文首行时，Monaco 粘性章节条的稳定高度。 */
+export function predictStickyChapterScrollHeight(
+  editor: monaco.editor.ICodeEditor,
+  chapters: readonly ChapterStickyLine[],
+  lineNumber: number,
+): number {
+  const stickyOption = editor.getOption(
+    monacoEditor.EditorOption.stickyScroll,
+  );
+  if (!stickyOption.enabled) return 0;
+
+  const maxLine = editor.getModel()?.getLineCount() ?? 0;
+  if (maxLine < 1) return 0;
+
+  const lineHeight = Math.max(
+    1,
+    editor.getOption(monacoEditor.EditorOption.lineHeight),
+  );
+  const viewportHeight = Math.max(1, editor.getLayoutInfo().height);
+  const rows = countStickyChapterRowsForLine(chapters, lineNumber, maxLine);
+  // Monaco 将 sticky 行数限制为 maxLineCount 与视口行数约 25% 的较小值。
+  const maxRows = Math.min(
+    stickyOption.maxLineCount,
+    Math.round((viewportHeight / lineHeight) * 0.25),
+  );
+  return Math.min(rows, Math.max(0, maxRows)) * lineHeight;
 }
 
 function buildChapterDocumentSymbols(


### PR DESCRIPTION
## 修改说明

按空格键向下翻页时，原行为是直接下翻一页并上调一行。
如果上方有二级粘性章节标题，就会覆盖掉上面的文字。

本次修改：

- 使用 Monaco 的完整可见范围定位上一页最下面的完整视觉行
- 将该视觉行对齐到新页面粘性章节标题下方
- 根据翻页落点的章节层级预测粘性标题高度

效果：向下翻页后，新页面第一行正好是上一页最下面且显示完整的一行。

当前翻页前后，如果有多层标题会覆盖第一行
<img width="4800" height="2700" alt="image" src="https://github.com/user-attachments/assets/4fd75c94-e72f-4afe-aa9d-7b87760689a8" />

修改后，保证保留上一页的完整最后一行：
<img width="4800" height="2700" alt="image" src="https://github.com/user-attachments/assets/caa8ec45-f240-4f58-a9d6-b92ea9a0f948" />

## 验证

- `npm ci` 安装依赖成功
- `npm run dev` 启动成功
- 已在普通窗口和全屏阅读模式下验证空格翻页
- 翻页后，新页面第一行是上一页最下面的完整一行

## 建议验证场景

- 普通窗口下连续按空格翻页
- 全屏阅读下连续按空格翻页
- 跨越章节标题时翻页